### PR TITLE
Added nvdashboard-server to job script

### DIFF
--- a/gpu_submit.sh
+++ b/gpu_submit.sh
@@ -12,6 +12,13 @@
 # activate the conda environment
 conda activate /ibex/scratch/kafkass/NER/conda-environment-examples/env
 
+# start the nvdashboard server in the background
+NVDASHBOARD_PORT=8000
+python -m jupyterlab_nvdashboard.server $NVDASHBOARD_PORT &
+NVDASHBOARD_PID=$!
+
 # run the training script
 python /ibex/scratch/kafkass/NER/simple_transformers/train_cuda_$1.py >/ibex/scratch/kafkass/NER/simple_transformers/cuda_$1_outputs/$1_results.txt
 
+# kill off the GPU monitoring processes
+kill $NVDASHBOARD_PID


### PR DESCRIPTION
This PR adds as a dashboard server for monitoring GPU, CPU, and memory utilization.The server is started as a background process prior to launching your training job and is accessible from a web browser at the following URL.

```
$IBEX_NODE_NAME.ibex.kaust.edu.sa:$NVDASHBOARD_PORT
```
where `$IBEX_NODE_NAME` is the name of the node on Ibex where your job is running and `$NVDASHBOARD_PORT` defaults to `8000`.